### PR TITLE
Fix version conflicts caused by PR#93

### DIFF
--- a/MaterialMessageBox/MaterialMessageBox.csproj
+++ b/MaterialMessageBox/MaterialMessageBox.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MaterialDesignColors" Version="1.2.2" />
-    <PackageReference Include="MaterialDesignThemes" Version="3.0.1" />
+    <PackageReference Include="MaterialDesignColors" Version="2.0.1" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump MaterialDesignThemes from 3.0.1 to 4.1.0. [(PR#93)](https://github.com/Gigas002/MaterialMessageBox/pull/93).
Hope this fix can help you.

Best regards,
sucrose